### PR TITLE
Fix a crash when trying to make a one time product purchase on Android.

### DIFF
--- a/Sources/SkipMarketplace/SkipMarketplace.swift
+++ b/Sources/SkipMarketplace/SkipMarketplace.swift
@@ -275,6 +275,12 @@ public struct Marketplace: Sendable {
     ///
     /// On iOS, the `offer` parameter must be a win-back offer. Configure a promotional offer by passing it in via the `purchaseOptions` parameter,
     /// leaving the `offer` parameter nil. (iOS applies introductory offers automatically.)
+    ///
+    /// On Android, prefer calling `purchase(item:offer:)` from Swift. The `purchaseOptions` overload is available
+    /// from `#if SKIP` Kotlin code but is excluded from the Swift-Kotlin bridge because the Skip build plugin
+    /// generates an incorrect JNI descriptor for nested Java classes (`BillingFlowParams$Builder` becomes
+    /// `BillingFlowParams/Builder`), causing a nil-unwrap crash at runtime.
+    // SKIP @nobridge
     public func purchase(item: ProductInfo, offer: OfferInfo? = nil, purchaseOptions: PlatformPurchaseOptions? = nil) async throws -> PurchaseTransaction? {
         #if SKIP
         // https://developer.android.com/google/play/billing/integrate#launch
@@ -294,16 +300,21 @@ public struct Marketplace: Sendable {
 
         let billingClient = try await connectBillingClient()
 
-        let purchaseResult: PurchaseResultInfo = try await withCheckedThrowingContinuation { continuation in
-            // hook into the purchasesUpdated() callback above with a continuation that will be invoked when the purchase is completed
-            purchasesUpdatedListeners.append(PurchaseListenerWrapper(once: true) { purchaseResult in
-                logger.info("purchases updated: result=\(purchaseResult.result) purchases=\(purchaseResult.purchases)")
-                continuation.resume(returning: purchaseResult)
-            })
+        // BillingClient 7+ requires launchBillingFlow to be called from the main thread.
+        // The enclosing Async.run{} body runs on Dispatchers.Default, so we switch to
+        // Dispatchers.Main for the entire billing-flow setup and result wait.
+        let purchaseResult: PurchaseResultInfo = withContext(Dispatchers.Main) {
+            try await withCheckedThrowingContinuation { continuation in
+                // hook into the purchasesUpdated() callback above with a continuation that will be invoked when the purchase is completed
+                purchasesUpdatedListeners.append(PurchaseListenerWrapper(once: true) { purchaseResult in
+                    logger.info("purchases updated: result=\(purchaseResult.result) purchases=\(purchaseResult.purchases)")
+                    continuation.resume(returning: purchaseResult)
+                })
 
-            let result = billingClient.launchBillingFlow(activity, billingFlowParams)
-            if result.responseCode != BillingClient.BillingResponseCode.OK {
-                continuation.resume(throwing: ErrorException(RuntimeException(errorMessage(for: result))))
+                let result = billingClient.launchBillingFlow(activity, billingFlowParams)
+                if result.responseCode != BillingClient.BillingResponseCode.OK {
+                    continuation.resume(throwing: ErrorException(RuntimeException(errorMessage(for: result))))
+                }
             }
         }
 
@@ -364,6 +375,25 @@ public struct Marketplace: Sendable {
         #endif
     }
     
+    /// Primary bridge-visible overload of `purchase` without `purchaseOptions`.
+    ///
+    /// This overload exists because the Skip build plugin generates an incorrect JNI descriptor
+    /// for nested Java classes such as `BillingFlowParams$Builder` (writes `BillingFlowParams/Builder`
+    /// instead of `BillingFlowParams$Builder`), causing a nil-unwrap crash when the bridge is loaded.
+    /// By omitting `purchaseOptions` from this overload's signature the generated JNI descriptor only
+    /// references `ProductInfo` and `OfferInfo`, both of which are top-level Skip classes with correct
+    /// descriptors. The full implementation (including optional `purchaseOptions`) is still reachable
+    /// from `#if SKIP` / Kotlin code via the `// SKIP @nobridge` overload above.
+    public func purchase(item: ProductInfo, offer: OfferInfo? = nil) async throws -> PurchaseTransaction? {
+        #if SKIP
+        return try await purchase(item: item, offer: offer, purchaseOptions: nil)
+        #elseif canImport(StoreKit)
+        return try await purchase(item: item, offer: offer, purchaseOptions: nil)
+        #else
+        fatalError("Unsupported platform")
+        #endif
+    }
+
     #if SKIP
     private func queryPurchasesAsync(_ productType: String) async throws -> List<Purchase> {
         let billingClient = try await connectBillingClient()


### PR DESCRIPTION
Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or **device**
- [x] OPTIONAL: I have tested my change on an Android emulator or **device**

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

These changes were entirely made by AI. I have tested them on real Android and iOS devices (installed via Play Store and TestFlight, not debug builds).

I deleted an additional hypothetical fix that the AI made that was not relevant to this PR.

-----
When attempting to make a purchase, my app was crashing with:

```
03-01 13:34:20.423 15410 15791 F SwiftRuntime: SkipMarketplace/SkipMarketplace_Bridge.swift:82: Fatal error: Unexpectedly found nil while unwrapping an Optional value
--------- beginning of crash
03-01 13:34:20.424 15410 15791 F libc    : Fatal signal 5 (SIGTRAP), code 1 (TRAP_BRKPT), fault addr 0x6f99195814 in tid 15791 (Thread-40), pid 15410 (app.bundle.id)
```

After a lot of headscratching I cloned skip-marketplace and threw Sonnet at it. Sonnet made the changes in this commit and said the following:

> Root cause of the crash (line 82 of the bridge file)
> 
> The Skip build plugin generates JNI method descriptors from Swift type signatures. When it encounters `PlatformPurchaseOptions` (a typealias for `com.android.billingclient.api.BillingFlowParams.Builder`) it naively converts all `.` separators to `/`, producing:
> `Lcom/android/billingclient/api/BillingFlowParams/Builder;`   ← WRONG 
> `Lcom/android/billingclient/api/BillingFlowParams$Builder; `  ← CORRECT
> In JNI, nested/inner classes use `$` not `/`. The generated bridge had this wrong signature, getMethodID returned nil, the ! force-unwrap fired → SIGTRAP.
> 
> Three changes in /Users/maxc/xcode/skip-marketplace/Sources/SkipMarketplace/SkipMarketplace.swift:
> 1. `// SKIP @nobridge on purchase(item:offer:purchaseOptions:)` — tells the Skip build plugin to skip bridge generation for this function, so the broken JNI descriptor is never produced.
> 2. New `purchase(item:offer:)` overload — this is the bridge-visible entry point. Its signature only contains `ProductInfo` and `OfferInfo` (both top-level Skip classes with correct descriptors). On `#if SKIP` it delegates directly to the full Kotlin implementation.
>  3. `withContext(Dispatchers.Main)` around `launchBillingFlow` — BillingClient 7+ requires `launchBillingFlow` to be called from the main thread. The enclosing `Async.run{}` runs on `Dispatchers.Default`, so this switches to the UI thread just for the billing-flow launch and waits for the result, then returns to the background.
> 
> After building, the new generated bridge will have:
> `sig: "(Lskip/marketplace/ProductInfo;Lskip/marketplace/OfferInfo;Lkotlin/jvm/functions/Function2;)V"`
> — no nested class, correct descriptor, no crash.

After using these changes, my app correctly shows the billing flow on Android. I re-tested iOS in app purchases too and they still work.

I am **not** a Kotlin or Android expert (nor a Skip expert), but (at least one of) these changes were needed in order for in app purchases to not crash on Android in my Skip Fuse app. So I wanted to contribute and maybe you can understand the bridge signature changes more / think of a better solution or realise this issue may be affecting other APIs too!

Happy to update/remove comments and/or code as you see fit.