### PR TITLE
Use `getName()` as the displayName on GPS, not `getTitle()`

### DIFF
--- a/Sources/SkipMarketplace/SkipMarketplace.swift
+++ b/Sources/SkipMarketplace/SkipMarketplace.swift
@@ -740,7 +740,7 @@ public struct ProductInfo {
 
     public var displayName: String {
         #if SKIP
-        product.getTitle()
+        product.getName()
         #elseif canImport(StoreKit)
         product.displayName
         #endif


### PR DESCRIPTION
`getName()` is a better "display name" than `getTitle()`

https://developer.android.com/reference/com/android/billingclient/api/ProductDetails

> `getTitle()`
> The title includes the name of the app which owns the product. Example: 100 Gold Coins (Coin selling app).

> `getName()`
> This method is similar to `getTitle` but does not include the name of the app which owns the product. Example: 100 Gold Coins

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

