### PR TITLE
Fix API match warnings

### DIFF
--- a/Sources/SkipMarketplace/SkipMarketplace.swift
+++ b/Sources/SkipMarketplace/SkipMarketplace.swift
@@ -386,8 +386,11 @@ public struct Marketplace: Sendable {
     public func fetchEntitlements() async throws -> [PurchaseTransaction] {
         var result: [PurchaseTransaction] = []
         #if SKIP
-        async let inAppPurchases = try await queryPurchasesAsync(BillingClient.ProductType.INAPP)
-        async let subsPurchases = try await queryPurchasesAsync(BillingClient.ProductType.SUBS)
+        // Defining local variables to workaround Skip API matching bug causing a spurious warning
+        let inApp: String = BillingClient.ProductType.INAPP
+        let subs: String = BillingClient.ProductType.SUBS
+        async let inAppPurchases = try await queryPurchasesAsync(inApp)
+        async let subsPurchases = try await queryPurchasesAsync(subs)
         
         for purchase in try await inAppPurchases {
             if purchase.getPurchaseState() == Purchase.PurchaseState.PURCHASED {


### PR DESCRIPTION
I'm unclear why, but Skip couldn't match the API when passing `BillingClient.ProductType.INAPP`. Defining local variables gave Skip the metadata it needs (they're just strings!) to match the API, fixing the warning.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

